### PR TITLE
Log phase start/end time

### DIFF
--- a/lib/chiapos/src/plotter_disk.hpp
+++ b/lib/chiapos/src/plotter_disk.hpp
@@ -90,23 +90,23 @@ class DiskPlotter {
 
         std::string plot_filename = filename + ".tmp";
 
-        std::cout << std::endl << "Starting phase 1/4: Forward Propagation..." << std::endl;
+        std::cout << std::endl << "Starting phase 1/4: Forward Propagation... " << Timer::GetNow();
         Timer p1;
         Timer all_phases;
         std::vector<uint64_t> results = WritePlotFile(plot_filename, k, id, memo, memo_len);
         p1.PrintElapsed("Time for phase 1 =");
 
-        std::cout << std::endl << "Starting phase 2/4: Backpropagation..." << std::endl;
+        std::cout << std::endl << "Starting phase 2/4: Backpropagation... " << Timer::GetNow();
         Timer p2;
         Backpropagate(filename, plot_filename, k, id, memo, memo_len, results);
         p2.PrintElapsed("Time for phase 2 =");
 
-        std::cout << std::endl << "Starting phase 3/4: Compression..." << std::endl;
+        std::cout << std::endl << "Starting phase 3/4: Compression... " << Timer::GetNow();
         Timer p3;
         Phase3Results res = CompressTables(k, results, filename, plot_filename, id, memo, memo_len);
         p3.PrintElapsed("Time for phase 3 =");
 
-        std::cout << std::endl << "Starting phase 4/4: Write Checkpoint tables..." << std::endl;
+        std::cout << std::endl << "Starting phase 4/4: Write Checkpoint tables... " << Timer::GetNow();
         Timer p4;
         WriteCTables(k, k + 1, filename, plot_filename, res);
         p4.PrintElapsed("Time for phase 4 =");

--- a/lib/chiapos/src/util.hpp
+++ b/lib/chiapos/src/util.hpp
@@ -50,6 +50,13 @@ class Timer {
         this->cpu_time_start_ = clock();
     }
 
+    static char* GetNow()
+    {
+        auto now = std::chrono::system_clock::now();
+        auto tt = std::chrono::system_clock::to_time_t(now);
+        return ctime(&tt); // ctime includes newline
+    }
+
     void PrintElapsed(std::string name) {
         auto end = std::chrono::steady_clock::now();
         auto wall_clock_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -59,7 +66,7 @@ class Timer {
 
         double cpu_ratio = static_cast<int>(10000 * (cpu_time_ms / wall_clock_ms)) / 100.0;
 
-        std::cout << name << " " << (wall_clock_ms / 1000.0)  << " seconds. CPU (" << cpu_ratio << "%)" << std::endl;
+        std::cout << name << " " << (wall_clock_ms / 1000.0)  << " seconds. CPU (" << cpu_ratio << "%) " << Timer::GetNow();
     }
 
  private:


### PR DESCRIPTION
Adds a timestamp at the beginning and end of each phase of plot creation as helpful information for plots with large k values.

```
Starting phase 1/4: Forward Propagation... Sun Feb  2 10:02:19 2020

Wrote: 151
Computing table 1
F1 complete, Time =  0.365 seconds. CPU (98.45%) Sun Feb  2 10:02:19 2020
```